### PR TITLE
treewide: Support for response files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ $ cat /tmp/demo.jsonl
 a la [Bear](https://github.com/rizsotto/Bear).
 * Supporting `cl.exe`.
 * Detailed support for non C/C++ languages.
-* Parsing arguments that are passed via `@file`.
 
 ## Contributing a new action
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "click ~= 7.1",
+        "typing_extensions",
     ],
     extras_require={
         "dev": [

--- a/src/canker/protocols.py
+++ b/src/canker/protocols.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from typing_extensions import Protocol
+
+from canker.enums import Lang
+
+
+class ArgsProtocol(Protocol):
+    @property
+    def args(self) -> List[str]:
+        ...  # pragma: no cover
+
+
+class LangProtocol(Protocol):
+    # NOTE(ww): This is a little silly, but neither inheriting from `ArgsProtocol`
+    # nor `self: ArgsProtocol` for `lang` works.
+    args: List[str]
+
+    @property
+    def lang(self) -> Lang:
+        ...  # pragma: no cover

--- a/src/canker/util.py
+++ b/src/canker/util.py
@@ -7,7 +7,7 @@ import fcntl
 import os
 import shlex
 import sys
-from typing import Any, Optional, Sequence
+from typing import Any, List, Optional, Sequence
 
 from canker.exceptions import CankerError
 
@@ -51,6 +51,31 @@ def rindex_prefix(items: Sequence[str], prefix: str) -> Optional[int]:
         if item.startswith(prefix):
             return len(items) - idx - 1
     return None
+
+
+def insert_items_at_idx(parent_items: Sequence[Any], idx: int, items: Sequence[Any]) -> List[Any]:
+    """
+    Inserts `items` at `idx` in `parent_items`.
+
+    Args:
+        parent_items (sequence of any): The parent sequence to insert within
+        idx (int): The index to insert at
+        items (sequence of any): The items to insert
+
+    Returns:
+        A new list containing both the parent and inserted items
+    """
+
+    def _insert_items_at_idx(parent_items, idx, items):
+        for pidx, item in enumerate(parent_items):
+            if pidx != idx:
+                print(item)
+                yield item
+            else:
+                for item in items:
+                    yield item
+
+    return list(_insert_items_at_idx(parent_items, idx, items))
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
These end up being useful, so support them.

Closes #9.