### PR TITLE
src, test: Propagate a wrapped tool's failure

### DIFF
--- a/src/canker/exceptions.py
+++ b/src/canker/exceptions.py
@@ -9,3 +9,11 @@ class CankerError(ValueError):
     """
 
     pass
+
+
+class BuildError(CankerError):
+    """
+    Raised whenever a wrapped tool fails.
+    """
+
+    pass

--- a/src/canker/tool.py
+++ b/src/canker/tool.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 from canker.enums import CompilerStage, Lang, OptLevel, Std
-from canker.exceptions import CankerError
+from canker.exceptions import BuildError, CankerError
 from canker.protocols import ArgsProtocol, IndexedUndefinesProtocol, LangProtocol
 from canker.util import insert_items_at_idx, load_actions, rindex_prefix
 
@@ -88,7 +88,9 @@ class Tool:
         """
         self._before_run()
 
-        subprocess.run([self.wrapped_tool(), *self.args])
+        status = subprocess.run([self.wrapped_tool(), *self.args])
+        if status.returncode != 0:
+            raise BuildError(f"{self.wrapped_tool()} exited with status code {status.returncode}")
 
         self._after_run()
 

--- a/test/test_tool.py
+++ b/test/test_tool.py
@@ -6,7 +6,7 @@ import pytest
 
 from canker import tool
 from canker.enums import CompilerStage, Lang, OptLevel, Std
-from canker.exceptions import CankerError
+from canker.exceptions import BuildError, CankerError
 
 
 def test_tool_doesnt_instantiate():
@@ -23,6 +23,12 @@ def test_tool_missing_wrapped_tool(monkeypatch):
     monkeypatch.delenv("CANKER_WRAPPED_CC")
     with pytest.raises(CankerError):
         tool.CC.wrapped_tool()
+
+
+def test_tool_fails(monkeypatch):
+    monkeypatch.setenv("CANKER_WRAPPED_CC", "false")
+    with pytest.raises(BuildError):
+        tool.CC([]).run()
 
 
 def test_tool_run(monkeypatch, tmp_path):


### PR DESCRIPTION
Canker should never mask a tool's failure, nor allow `after_run` steps to run when a tool has failed.

cc @anniecherk