### PR TITLE
feat(tool): copy the env with each tool

### DIFF
--- a/src/blight/cli.py
+++ b/src/blight/cli.py
@@ -59,7 +59,7 @@ def _export_guess_wrapped():
 
 
 def _swizzle_path():
-    blight_dir = Path(tempfile.mkdtemp(prefix="blight"))
+    blight_dir = Path(tempfile.mkdtemp(suffix=blight.tool.SWIZZLE_SENTINEL))
 
     for shim, tool in SHIM_MAP.items():
         shim_path = blight_dir / shim

--- a/src/blight/tool.py
+++ b/src/blight/tool.py
@@ -67,6 +67,7 @@ class Tool:
         if self.__class__ == Tool:
             raise NotImplementedError(f"can't instantiate {self.__class__.__name__} directly")
         self._args = args
+        self._env = dict(os.environ)
         self._cwd = Path(os.getcwd()).resolve()
         self._actions = load_actions()
 
@@ -101,6 +102,7 @@ class Tool:
             "wrapped_tool": self.wrapped_tool(),
             "args": self.args,
             "cwd": str(self._cwd),
+            "env": self._env,
         }
 
     @property

--- a/src/blight/tool.py
+++ b/src/blight/tool.py
@@ -17,6 +17,8 @@ from blight.util import insert_items_at_idx, load_actions, rindex_prefix, ritem_
 
 logger = logging.getLogger(__name__)
 
+SWIZZLE_SENTINEL = "@blight-swizzle@"
+
 BLIGHT_TOOL_MAP = {
     "blight-cc": "CC",
     "blight-c++": "CXX",
@@ -67,9 +69,20 @@ class Tool:
         if self.__class__ == Tool:
             raise NotImplementedError(f"can't instantiate {self.__class__.__name__} directly")
         self._args = args
-        self._env = dict(os.environ)
+        self._env = self._fixup_env()
         self._cwd = Path(os.getcwd()).resolve()
         self._actions = load_actions()
+
+    def _fixup_env(self):
+        """
+        Fixes up `os.environ` to remove any references to blight's swizzled paths,
+        if any are present.
+        """
+        env = dict(os.environ)
+        paths = env.get("PATH", "").split(os.pathsep)
+        paths = [p for p in paths if not Path(p).name.endswith(SWIZZLE_SENTINEL)]
+        env["PATH"] = os.pathsep.join(paths)
+        return env
 
     def _before_run(self):
         for action in self._actions:

--- a/test/test_tool.py
+++ b/test/test_tool.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shlex
 import shutil
 
@@ -229,6 +230,7 @@ def test_cc(flags, lang, std, stage, opt):
         "std": std.name,
         "stage": stage.name,
         "opt": opt.name,
+        "env": dict(os.environ),
     }
 
 
@@ -259,6 +261,7 @@ def test_cxx(flags, lang, std, stage, opt):
         "std": std.name,
         "stage": stage.name,
         "opt": opt.name,
+        "env": dict(os.environ),
     }
 
 
@@ -286,6 +289,7 @@ def test_cpp(flags, lang, std):
         "cwd": str(cpp.cwd),
         "lang": lang.name,
         "std": std.name,
+        "env": dict(os.environ),
     }
 
 
@@ -299,6 +303,7 @@ def test_ld():
         "wrapped_tool": ld.wrapped_tool(),
         "args": [],
         "cwd": str(ld.cwd),
+        "env": dict(os.environ),
     }
 
 
@@ -328,6 +333,7 @@ def test_as():
         "wrapped_tool": as_.wrapped_tool(),
         "args": [],
         "cwd": str(as_.cwd),
+        "env": dict(os.environ),
     }
 
 
@@ -341,4 +347,5 @@ def test_ar():
         "wrapped_tool": ar.wrapped_tool(),
         "args": [],
         "cwd": str(ar.cwd),
+        "env": dict(os.environ),
     }

--- a/test/test_tool.py
+++ b/test/test_tool.py
@@ -32,6 +32,16 @@ def test_tool_fails(monkeypatch):
         tool.CC([]).run()
 
 
+def test_tool_env_filters_swizzle_path(monkeypatch):
+    path = os.getenv("PATH")
+    monkeypatch.setenv("PATH", f"/tmp/does-not-exist-{tool.SWIZZLE_SENTINEL}:{path}")
+
+    cc = tool.CC(["-v"])
+
+    env = cc.asdict()["env"]
+    assert tool.SWIZZLE_SENTINEL not in env["PATH"]
+
+
 def test_tool_run(monkeypatch, tmp_path):
     bench_output = tmp_path / "bench.jsonl"
     monkeypatch.setenv("BLIGHT_ACTIONS", "Benchmark")


### PR DESCRIPTION
~~The copy probably isn't technically necessary (like cwd) since we could just use `os.environ` in each action, but whatever.~~


cc @pgoodman 