### PR TITLE
setup, blight: add blight-exec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     entry_points={
         "console_scripts": [
             "blight-env = blight.cli:env",
+            "blight-exec = blight.cli:exec_",
             "blight-cc = blight.cli:tool",
             "blight-c++ = blight.cli:tool",
             "blight-cpp = blight.cli:tool",


### PR DESCRIPTION
Examples:

```bash
blight-exec --guess-wrapped make
blight-exec --swizzle-path --guess-wrapped cc -- -some -cc -flags
```

Users still have to set up actions manually. 

Closes #43377.