### PR TITLE
blight/tool: run our wrapped tool without a swizzled PATH

### DIFF
--- a/src/blight/tool.py
+++ b/src/blight/tool.py
@@ -130,7 +130,7 @@ class Tool:
         self._before_run()
 
         if not self._skip_run:
-            status = subprocess.run([self.wrapped_tool(), *self.args])
+            status = subprocess.run([self.wrapped_tool(), *self.args], env=self._env)
             if status.returncode != 0:
                 raise BuildError(
                     f"{self.wrapped_tool()} exited with status code {status.returncode}"


### PR DESCRIPTION
This fixes a forkbomb that occurs when our wrapped tool is **itself** some kind of compiler wrapper, such as WLLVM or GLLVM. These tools should be run with an unmodified `PATH`, allowing them to access their corresponding real build tools without interference.