### PR TITLE
FindOutputs: refactor, store outputs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,11 @@ setup(
     },
     platforms="any",
     python_requires=">=3.7",
-    install_requires=["click ~= 7.1", "typing_extensions"],
+    install_requires=[
+        "click ~= 7.1",
+        "typing_extensions",
+        "pydantic ~= 1.7",
+    ],
     extras_require={
         "dev": [
             "flake8",

--- a/src/blight/actions/find_outputs.py
+++ b/src/blight/actions/find_outputs.py
@@ -132,7 +132,7 @@ class FindOutputs(Action):
 
             for output in self._outputs:
                 if not output.path.exists():
-                    logger.warning(f"{tool=}'s output ({output.path}) does not exist")
+                    logger.warning(f"tool={tool}'s output ({output.path}) does not exist")
                     continue
 
                 # Outputs aren't guaranteed to have unique basenames and subsequent

--- a/src/blight/actions/find_outputs.py
+++ b/src/blight/actions/find_outputs.py
@@ -3,13 +3,17 @@ The `FindOutputs` action.
 """
 
 import enum
-import json
-from collections import defaultdict
+import logging
 from pathlib import Path
+from typing import List, Optional
+
+from pydantic import BaseModel
 
 from blight.action import Action
-from blight.tool import CC, CXX, LD
+from blight.tool import CC, CXX, LD, Tool
 from blight.util import flock_append
+
+logger = logging.getLogger(__name__)
 
 
 @enum.unique
@@ -26,6 +30,21 @@ class OutputKind(enum.Enum):
     Executable: str = "executable"
     KernelModule: str = "kernel"
     Unknown: str = "unknown"
+
+
+class Output(BaseModel):
+    kind: OutputKind
+    path: Path
+    store_path: Optional[Path]
+
+
+class OutputRecord(BaseModel):
+    tool: Tool
+    outputs: List[Output]
+
+    class Config:
+        arbitrary_types_allowed = True
+        json_encoders = {Tool: lambda t: t.asdict()}
 
 
 OUTPUT_SUFFIX_KIND_MAP = {
@@ -53,24 +72,35 @@ This mapping is not exhaustive.
 
 class FindOutputs(Action):
     def before_run(self, tool):
-        output_map = defaultdict(list)
-        for output in tool.outputs:
-            output = Path(output)
-            if not output.is_absolute():
-                output = tool.cwd / output
+        outputs = []
+        for output_path in tool.outputs:
+            output_path = Path(output_path)
+            if not output_path.is_absolute():
+                output_path = tool.cwd / output_path
 
-            # Special case: a.out is produced by both the linker
-            # and compiler tools by default.
-            if output.name == "a.out" and tool.__class__ in [CC, CXX, LD]:
-                output_map[OutputKind.Executable.value].append(str(output))
+            # Special case: a.out is produced by both the linker and compiler tools by default.
+            if output_path.name == "a.out" and tool.__class__ in [CC, CXX, LD]:
+                kind = OutputKind.Executable
             else:
-                kind = OUTPUT_SUFFIX_KIND_MAP.get(output.suffix, OutputKind.Unknown)
-                output_map[kind.value].append(str(output))
+                kind = OUTPUT_SUFFIX_KIND_MAP.get(output_path.suffix, OutputKind.Unknown)
 
-        output = Path(self._config["output"])
-        with flock_append(output) as io:
-            outputs_record = {"tool": tool.asdict(), "outputs": output_map}
-            print(json.dumps(outputs_record), file=io)
+            outputs.append(Output(kind=kind, path=output_path))
 
-    # TODO(ww): Could do after_run here and check whether each output
-    # in output_map was actually created.
+        self._outputs = outputs
+
+    def after_run(self, tool):
+        store = self._config.get("store")
+        if store is not None:
+            Path(store).mkdir(parents=True, exist_ok=True)
+
+            for output in self.outputs["outputs"]:
+                output = Path(output)
+                if not output.exists():
+                    logger.warning(f"{tool=}'s output ({output}) does not exist")
+                    continue
+
+        output_record = OutputRecord(tool=tool, outputs=self._outputs)
+
+        record_output_path = Path(self._config["output"])
+        with flock_append(record_output_path) as io:
+            print(output_record.json(), file=io)

--- a/test/actions/test_find_outputs.py
+++ b/test/actions/test_find_outputs.py
@@ -11,9 +11,16 @@ def test_find_outputs(tmp_path):
     find_outputs = FindOutputs({"output": output})
     cc = CC(["-o", "foo", "foo.c"])
     find_outputs.before_run(cc)
+    find_outputs.after_run(cc)
 
     outputs = json.loads(output.read_text())["outputs"]
-    assert outputs[OutputKind.Executable.value] == [str(cc.cwd / "foo")]
+    assert outputs == [
+        {
+            "kind": OutputKind.Executable.value,
+            "path": str(cc.cwd / "foo"),
+            "store_path": None,
+        }
+    ]
 
 
 def test_find_outputs_multiple(tmp_path):
@@ -25,10 +32,16 @@ def test_find_outputs_multiple(tmp_path):
     find_outputs = FindOutputs({"output": output})
     cc = CC(["-c", *[str(fake_c) for fake_c in fake_cs]])
     find_outputs.before_run(cc)
+    find_outputs.after_run(cc)
 
     outputs = json.loads(output.read_text())["outputs"]
-    assert outputs[OutputKind.Object.value] == [
-        str(cc.cwd / fake_c.with_suffix(".o").name) for fake_c in fake_cs
+    assert outputs == [
+        {
+            "kind": OutputKind.Object.value,
+            "path": str(cc.cwd / fake_c.with_suffix(".o").name),
+            "store_path": None,
+        }
+        for fake_c in fake_cs
     ]
 
 
@@ -38,6 +51,13 @@ def test_find_outputs_handles_a_out(tmp_path):
     find_outputs = FindOutputs({"output": output})
     cc = CC(["foo.c"])
     find_outputs.before_run(cc)
+    find_outputs.after_run(cc)
 
     outputs = json.loads(output.read_text())["outputs"]
-    assert outputs[OutputKind.Executable.value] == [str(cc.cwd / "a.out")]
+    assert outputs == [
+        {
+            "kind": OutputKind.Executable.value,
+            "path": str(cc.cwd / "a.out"),
+            "store_path": None,
+        }
+    ]

--- a/test/actions/test_find_outputs.py
+++ b/test/actions/test_find_outputs.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 
 from blight.actions import FindOutputs
@@ -58,6 +59,51 @@ def test_find_outputs_handles_a_out(tmp_path):
         {
             "kind": OutputKind.Executable.value,
             "path": str(cc.cwd / "a.out"),
+            "store_path": None,
+        }
+    ]
+
+
+def test_find_outputs_store(tmp_path):
+    output = tmp_path / "outputs.jsonl"
+    store = tmp_path / "store"
+    contents = b"not a real object file"
+    contents_digest = hashlib.sha256(contents).hexdigest()
+    dummy_foo_o = tmp_path / "foo.o"
+    dummy_foo_o_store = store / f"{dummy_foo_o.name}-{contents_digest}"
+
+    find_outputs = FindOutputs({"output": output, "store": store})
+    cc = CC(["-c", "foo.c", "-o", str(dummy_foo_o)])
+    find_outputs.before_run(cc)
+    # Pretend to be the compiler: write some junk to dummy_foo_o
+    dummy_foo_o.write_bytes(contents)
+    find_outputs.after_run(cc)
+
+    outputs = json.loads(output.read_text())["outputs"]
+    assert outputs == [
+        {
+            "kind": OutputKind.Object.value,
+            "path": str(dummy_foo_o),
+            "store_path": str(dummy_foo_o_store),
+        }
+    ]
+
+
+def test_find_outputs_store_output_does_not_exist(tmp_path):
+    output = tmp_path / "outputs.jsonl"
+    store = tmp_path / "store"
+    dummy_foo_o = tmp_path / "foo.o"
+
+    find_outputs = FindOutputs({"output": output, "store": store})
+    cc = CC(["-c", "foo.c", "-o", str(dummy_foo_o)])
+    find_outputs.before_run(cc)
+    find_outputs.after_run(cc)
+
+    outputs = json.loads(output.read_text())["outputs"]
+    assert outputs == [
+        {
+            "kind": OutputKind.Object.value,
+            "path": str(dummy_foo_o),
             "store_path": None,
         }
     ]


### PR DESCRIPTION
Refactors the output structure of `FindOutputs`, and uses Pydantic internally to model the output structure.

Also introduces the `store` setting, which can be used to pass a directory into `FindOutputs`. When supplied, the store directory will be used to store a copy of each build output, unique'd on a hash of their contents.

Fixes #43383.

cc @thinkmoore 