### PR TITLE
AR fixes

### DIFF
--- a/src/blight/tool.py
+++ b/src/blight/tool.py
@@ -789,10 +789,17 @@ class AS(ResponseFileMixin, Tool):
         return f"<AS {self.wrapped_tool()}>"
 
 
-class AR(Tool):
+class AR(ResponseFileMixin, Tool):
     """
     Represents the archiver.
     """
+
+    @property
+    def outputs(self) -> List[str]:
+        """
+        Specializes `Tool.outputs` for the archiver.
+        """
+        return []
 
     def __repr__(self) -> str:
         return f"<AR {self.wrapped_tool()}>"

--- a/src/blight/tool.py
+++ b/src/blight/tool.py
@@ -799,6 +799,28 @@ class AR(ResponseFileMixin, Tool):
         """
         Specializes `Tool.outputs` for the archiver.
         """
+
+        # TODO(ww): This doesn't support `ar x`, which explodes the archive
+        # (i.e., treats it as input) instead of treats it as output.
+        # It would be pretty strange for a build system to do this, but it's
+        # probably something we should detect at the very least.
+
+        # TODO(ww): We also don't support `ar t`, which queries the given
+        # archive to provide a table listing of its contents.
+
+        # NOTE(ww): `ar`'s POSIX and GNU CLIs are annoyingly complicated.
+        # We save ourselves some pain by scanning from left-to-right, looking
+        # for the first argument that looks like an archive output
+        # (since the archiver only ever produces one output at a time).
+        for arg in self.canonicalized_args:
+            if arg.startswith("-"):
+                continue
+
+            maybe_archive_suffixes = Path(arg).suffixes
+            if len(maybe_archive_suffixes) > 0 and maybe_archive_suffixes[0] == ".a":
+                return [arg]
+
+        logger.debug("couldn't infer output for archiver")
         return []
 
     def __repr__(self) -> str:

--- a/test/actions/test_find_outputs.py
+++ b/test/actions/test_find_outputs.py
@@ -125,7 +125,7 @@ def test_find_outputs_annoying_so_prefixes(tmp_path, soname):
     output = tmp_path / "outputs.jsonl"
 
     find_outputs = FindOutputs({"output": output})
-    cc = CC(["cc", "-shared", "-o", soname, "foo.c"])
+    cc = CC(["-shared", "-o", soname, "foo.c"])
     find_outputs.before_run(cc)
     find_outputs.after_run(cc)
 

--- a/test/test_tool.py
+++ b/test/test_tool.py
@@ -379,6 +379,23 @@ def test_ar():
     }
 
 
+@pytest.mark.parametrize(
+    ("flags", "outputs"),
+    [
+        ("cr foo.a a.o b.o", ["foo.a"]),
+        ("-X64_32 cr foo.a a.o b.o", ["foo.a"]),
+        ("r foo.a bar.o", ["foo.a"]),
+        ("ru foo.a bar.o", ["foo.a"]),
+        ("d foo.a bar.o", ["foo.a"]),
+        ("--help", []),
+    ],
+)
+def test_ar_output_forms(flags, outputs):
+    ar = tool.AR(shlex.split(flags))
+
+    assert ar.outputs == outputs
+
+
 def test_strip():
     strip = tool.STRIP([])
 


### PR DESCRIPTION
"Fixes" `AR.outputs`, and adds support for response files (since some archivers, like BFD's, support it).

Closes #43398.