### PR TITLE
src, test: add a journaling mode

### DIFF
--- a/src/blight/action.py
+++ b/src/blight/action.py
@@ -2,7 +2,7 @@
 The different actions supported by blight.
 """
 
-from typing import Dict
+from typing import Any, Dict, Optional
 
 import blight.tool
 from blight.tool import Tool
@@ -15,6 +15,7 @@ class Action:
 
     def __init__(self, config: Dict[str, str]):
         self._config = config
+        self._result: Optional[Dict[str, Any]] = None
 
     def _should_run_on(self, tool: Tool) -> bool:
         return True
@@ -44,6 +45,13 @@ class Action:
     def _after_run(self, tool: Tool, *, run_skipped=False) -> None:
         if self._should_run_on(tool):
             self.after_run(tool, run_skipped=run_skipped)
+
+    @property
+    def result(self) -> Optional[Dict[str, Any]]:
+        """
+        Returns the result computed by this action, if there is one.
+        """
+        return self._result
 
 
 class CCAction(Action):

--- a/src/blight/actions/record.py
+++ b/src/blight/actions/record.py
@@ -12,12 +12,14 @@ from blight.util import flock_append
 
 class Record(Action):
     def after_run(self, tool: Tool, *, run_skipped: bool = False):
-        record_file = Path(self._config["output"])
-
         # TODO(ww): Restructure this dictionary; it should be more like:
         # { run: {...}, tool: {...}}
         tool_record = tool.asdict()
         tool_record["run_skipped"] = run_skipped
 
-        with flock_append(record_file) as io:
-            print(json.dumps(tool_record), file=io)
+        if tool.is_journaling():
+            self._result = tool_record
+        else:
+            record_file = Path(self._config["output"])
+            with flock_append(record_file) as io:
+                print(json.dumps(tool_record), file=io)

--- a/src/blight/util.py
+++ b/src/blight/util.py
@@ -199,7 +199,7 @@ def insert_items_at_idx(parent_items: Sequence[Any], idx: int, items: Sequence[A
 
 
 @contextlib.contextmanager
-def flock_append(filename):
+def flock_append(filename: os.PathLike):
     """
     Open the given file for appending, acquiring an exclusive lock on it in
     the process.

--- a/test/test_tool.py
+++ b/test/test_tool.py
@@ -56,6 +56,19 @@ def test_tool_run(monkeypatch, tmp_path):
     assert isinstance(bench_record["elapsed"], int)
 
 
+def test_tool_run_journaling(monkeypatch, tmp_path):
+    journal_output = tmp_path / "journal.jsonl"
+    monkeypatch.setenv("BLIGHT_ACTIONS", "Record:Benchmark:FindOutputs")
+    monkeypatch.setenv("BLIGHT_JOURNAL_PATH", str(journal_output))
+
+    cc = tool.CC(["-v"])
+    cc.run()
+
+    journal = json.loads(journal_output.read_text())
+    assert set(journal.keys()) == {"Record", "Benchmark", "FindOutputs"}
+    assert all(isinstance(v, dict) for v in journal.values())
+
+
 def test_tool_args_property():
     cpp = tool.CPP(["a", "b", "c"])
 


### PR DESCRIPTION
Can be enabled by setting `BLIGHT_JOURNAL_PATH=/foo/bar`.

Closes #43416.