### PR TITLE
Add config option to `InjectFlags` for linker-only flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ pip-wheel-metadata/
 *.egg-info/
 __pycache__/
 .coverage
+.idea
 html/
 dist/

--- a/src/blight/actions/inject_flags.py
+++ b/src/blight/actions/inject_flags.py
@@ -6,7 +6,7 @@ import logging
 import shlex
 
 from blight.action import CompilerAction
-from blight.enums import Lang
+from blight.enums import CompilerStage, Lang
 from blight.tool import CompilerTool
 
 logger = logging.getLogger(__name__)
@@ -16,8 +16,14 @@ class InjectFlags(CompilerAction):
     """
     An action for injecting flags into compiler commands (specifically, `cc` and `c++`).
 
-    This action takes `CFLAGS`, `CXXFLAGS`, and `CPPFLAGS` in its configuration and
-    appends them (after shell-splitting) as appropriate.
+    This action takes the following flags in its configuration and appends them
+    (after shell-splitting) as appropriate:
+    - `CFLAGS`: Flags to append to every C compiler call
+    - `CFLAGS_LINKER`: Flags to append to every C compiler call that runs the linking
+     stage (i.e: no `-c`, `-e`, `-S`, etc. flags present)
+    - `CXXFLAGS`: Same as `CFLAGS` but for C++
+    - `CFLAGS_LINKER`: Same as `CFLAGS_LINKER`, but for C++
+    - `CPPFLAGS`: Flags to append for the preprocessor stage
 
     For example:
 
@@ -37,14 +43,20 @@ class InjectFlags(CompilerAction):
     # is safely specialized for `CompilerTool`.
     def before_run(self, tool: CompilerTool) -> None:  # type: ignore
         cflags = shlex.split(self._config.get("CFLAGS", ""))
+        cflags_linker = shlex.split(self._config.get("CFLAGS_LINKER", ""))
         cxxflags = shlex.split(self._config.get("CXXFLAGS", ""))
+        cxxflags_linker = shlex.split(self._config.get("CXXFLAGS_LINKER", ""))
         cppflags = shlex.split(self._config.get("CPPFLAGS", ""))
 
         if tool.lang == Lang.C:
             tool.args += cflags
             tool.args += cppflags
+            if tool.stage is CompilerStage.AllStages:
+                tool.args += cflags_linker
         elif tool.lang == Lang.Cxx:
             tool.args += cxxflags
             tool.args += cppflags
+            if tool.stage is CompilerStage.AllStages:
+                tool.args += cxxflags_linker
         else:
             logger.debug("not injecting flags for an unknown language")

--- a/test/actions/test_inject_flags.py
+++ b/test/actions/test_inject_flags.py
@@ -26,6 +26,32 @@ def test_inject_flags_cxx():
     assert cxx.args == shlex.split("-fake -flags -more -flags -bar")
 
 
+def test_inject_linker_flags():
+    inject_flags = InjectFlags(
+        {
+            "CFLAGS": "-cc-flags",
+            "CFLAGS_LINKER": "-c-linker-flags",
+            "CXXFLAGS": "-cxx-flags",
+            "CXXFLAGS_LINKER": "-cxx-linker-flags",
+        }
+    )
+
+    cc_nolink = CC(["-c"])
+    cc_link = CC(["-fake", "-flags"])
+    cxx_nolink = CXX(["-c"])
+    cxx_link = CXX(["-fake", "-flags"])
+
+    inject_flags.before_run(cc_nolink)
+    inject_flags.before_run(cc_link)
+    inject_flags.before_run(cxx_nolink)
+    inject_flags.before_run(cxx_link)
+
+    assert cc_nolink.args == shlex.split("-c -cc-flags")
+    assert cc_link.args == shlex.split("-fake -flags -cc-flags -c-linker-flags")
+    assert cxx_nolink.args == shlex.split("-c -cxx-flags")
+    assert cxx_link.args == shlex.split("-fake -flags -cxx-flags -cxx-linker-flags")
+
+
 def test_inject_flags_unknown_lang():
     inject_flags = InjectFlags(
         {"CFLAGS": "-these -are -ignored", "CXXFLAGS": "-so -are -these", "CPPFLAGS": "-and -this"}


### PR DESCRIPTION
When using the `InjectFlags` action with linker flags (such as `-L/path/to/lib`), if the compiler tool is run in such a way that the linking stage is not included (like with the `-c`, `-E`, and `-S` options), the compiler will emit a warning:
```bash
CC build/release/source/fitz/output-ps.o
clang-13: warning: -Wl,--start-group: 'linker' input unused [-Wunused-command-line-argument]
clang-13: warning: /cxx_libs/clean_build/lib/libc++.a: 'linker' input unused [-Wunused-command-line-argument]
clang-13: warning: /cxx_libs/clean_build/lib/libc++abi.a: 'linker' input unused [-Wunused-command-line-argument]
clang-13: warning: -lpthread: 'linker' input unused [-Wunused-command-line-argument]
clang-13: warning: -Wl,--end-group: 'linker' input unused [-Wunused-command-line-argument]
```

This PR adds two new configuration options for `InjectFlags`: `CFLAGS_LINKER` and `CXXFLAGS_LINKER`, which can be used like this:

```bash
export BLIGHT_ACTIONS="InjectFlags"
export BLIGHT_ACTION_INJECTFLAGS="CFLAGS='-g -O0' CFLAGS_LINKER='-lm -L/path/lib/' CPPFLAGS='-DWHATEVER'"
```    

Then, the flags specified in the `LINKER` options will only be appended if the compiler tool is in the `AllStages` stage (which includes linking), avoiding the `linker input unused` warnings.