### PR TITLE
Add option for `FindOutputs` to not append content hash to filename

### DIFF
--- a/src/blight/actions/find_outputs.py
+++ b/src/blight/actions/find_outputs.py
@@ -159,7 +159,10 @@ class FindOutputs(Action):
                 # in-place, so we give each output a `store_path` based on a hash
                 # of its content.
                 content_hash = hashlib.sha256(output.path.read_bytes()).hexdigest()
-                output_store_path = store_path / f"{output.path.name}-{content_hash}"
+                # Append hash to the filename unless `append_hash=false` is specified in the config
+                append_hash = self._config.get("append_hash") != "false"
+                filename = f"{output.path.name}-{content_hash}" if append_hash else output.path.name
+                output_store_path = store_path / filename
                 if not output_store_path.exists():
                     shutil.copy(output.path, output_store_path)
                 output.store_path = output_store_path


### PR DESCRIPTION
By default, using `FindOutputs` with `store=/some/path` copies all outputs to `/some/path`, renaming them so that their content hash is appended to the filename: `/some/path/my_output.out-${content-hash}`.

This is done due to the possibility of several outputs at different stages of the compilation process having the same filename. While this is the right thing to do (in order to avoid silently replacing outputs with the same name), an option to disable this behavior is nice for those cases where we don't need it (due to the outputs we are interested in having unique names).

This adds a config option `append_hash` that allows the user to disable the behavior by specifying `append_hash=false`. Any other value will default to the current behavior (appending the hash).

An example of it's use would be:
```bash
$ eval $(blight-env --guess-wrapped)
$ export BLIGHT_ACTIONS="FindOutputs"
$ export BLIGHT_ACTION_RECORD="output=/tmp/demo.jsonl store=/my/store append_hash=false"
```