### PR TITLE
Add `IgnoreFlags` action

### DIFF
--- a/src/blight/actions/__init__.py
+++ b/src/blight/actions/__init__.py
@@ -6,6 +6,7 @@ from .benchmark import Benchmark  # noqa: F401
 from .cc_for_cxx import CCForCXX  # noqa: F401
 from .embed_bitcode import EmbedBitcode  # noqa: F401
 from .find_outputs import FindOutputs  # noqa: F401
+from .ignore_flags import IgnoreFlags  # noqa: F401
 from .ignore_flto import IgnoreFlto  # noqa: F401
 from .ignore_werror import IgnoreWerror  # noqa: F401
 from .inject_flags import InjectFlags  # noqa: F401

--- a/src/blight/actions/ignore_flags.py
+++ b/src/blight/actions/ignore_flags.py
@@ -1,0 +1,41 @@
+"""
+The `IgnoreFlags` action.
+"""
+
+import logging
+import shlex
+
+from blight.action import CompilerAction
+from blight.enums import Lang
+from blight.tool import CompilerTool
+
+logger = logging.getLogger(__name__)
+
+
+class IgnoreFlags(CompilerAction):
+    """
+    An action for ignoring specific flags passed to compiler
+    commands (specifically, `cc` and `c++`).
+
+    For example:
+
+    ```bash
+    export BLIGHT_WRAPPED_CC=clang
+    export BLIGHT_ACTIONS="IgnoreFlags"
+    export BLIGHT_ACTIONS_IGNOREFLAGS="FLAGS='-Werror -ffunction-sections'"
+    make CC=blight-cc
+    ```
+
+    will cause blight to remove `-Werror` and `--ffunction-sections` arguments
+    from each `clang` invocation.
+    """
+
+    # NOTE(ww): type ignore here because mypy thinks this is a Liskov
+    # substitution principle violation -- it can't see that `CompilerAction`
+    # is safely specialized for `CompilerTool`.
+    def before_run(self, tool: CompilerTool) -> None:  # type: ignore
+        ignore_flags = shlex.split(self._config.get("FLAGS", ""))
+        if tool.lang in [Lang.C, Lang.Cxx]:
+            tool.args = [a for a in tool.args if a not in ignore_flags]
+        else:
+            logger.debug("not ignoring flags for an unknown language")

--- a/test/actions/test_ignore_flags.py
+++ b/test/actions/test_ignore_flags.py
@@ -1,0 +1,22 @@
+import shlex
+
+from blight.actions import IgnoreFlags
+from blight.tool import CC, CXX
+
+
+def test_ignore_flags():
+    ignore_flags = IgnoreFlags({"FLAGS": "-Wextra -ffunction-sections"})
+
+    for tool in [CC, CXX]:
+        tool = CC(["-Wall", "-ffunction-sections", "-O3", "-ffunction-sections", "-Wextra"])
+        ignore_flags.before_run(tool)
+        assert tool.args == shlex.split("-Wall -O3")
+
+
+def test_ignore_werror_unknown_lang():
+    ignore_flags = IgnoreFlags({"FLAGS": "-Wextra -ffunction-sections"})
+    cxx = CXX(["-x", "-unknownlanguage", "-Werror"])
+
+    ignore_flags.before_run(cxx)
+
+    assert cxx.args == shlex.split("-x -unknownlanguage -Werror")


### PR DESCRIPTION
This PR adds a new `IgnoreFlags` action, which is a generalization of the existing `IgnoreWerror` and the `IgnoreFlto` actions.
Via the action's config, the user can specify the flags which should be discarded from the calls to the compilers:

```bash
export BLIGHT_WRAPPED_CC=clang
export BLIGHT_ACTIONS="IgnoreFlags"
export BLIGHT_ACTIONS_IGNOREFLAGS="FLAGS='-Werror -ffunction-sections'"
make CC=blight-cc
```
will discard any `-Werror` and `-ffunction-sections` arguments from any `clang` calls.

