### PR TITLE
src, test: Adds a basic `FindInputs` action

### DIFF
--- a/src/blight/actions/__init__.py
+++ b/src/blight/actions/__init__.py
@@ -5,6 +5,7 @@ Actions supported by blight.
 from .benchmark import Benchmark  # noqa: F401
 from .cc_for_cxx import CCForCXX  # noqa: F401
 from .embed_bitcode import EmbedBitcode  # noqa: F401
+from .find_inputs import FindInputs  # noqa: F401
 from .find_outputs import FindOutputs  # noqa: F401
 from .ignore_flags import IgnoreFlags  # noqa: F401
 from .ignore_flto import IgnoreFlto  # noqa: F401

--- a/src/blight/actions/find_inputs.py
+++ b/src/blight/actions/find_inputs.py
@@ -3,14 +3,14 @@ The `FindInputs` action.
 """
 
 from pathlib import Path
-from typing import Optional, List
+from typing import List, Optional
 
 from pydantic import BaseModel
 
 from blight.action import Action
+from blight.constants import INPUT_SUFFIX_KIND_MAP
 from blight.enums import InputKind
 from blight.tool import Tool
-from blight.constants import INPUT_SUFFIX_KIND_MAP
 from blight.util import flock_append
 
 

--- a/src/blight/actions/find_inputs.py
+++ b/src/blight/actions/find_inputs.py
@@ -1,0 +1,104 @@
+"""
+The `FindInputs` action.
+"""
+
+from pathlib import Path
+from typing import Optional, List
+
+from pydantic import BaseModel
+
+from blight.action import Action
+from blight.enums import InputKind
+from blight.tool import Tool
+from blight.constants import INPUT_SUFFIX_KIND_MAP
+from blight.util import flock_append
+
+
+class Input(BaseModel):
+    """
+    Represents a single input to a tool.
+    """
+
+    kind: InputKind
+    """
+    The kind of input.
+    """
+
+    prenormalized_path: str
+    """
+    The path to the input, as passed directly to the tool itself.
+
+    This copy of the path may be relative; consumers should prefer
+    `path` for an absolute copy.
+    """
+
+    path: Path
+    """
+    The path to the input, as created by the tool.
+
+    **NOTE**: This path may not actually exist, as a build system may arbitrarily
+    choose to rename or relocate any inputs consumed by individual tools.
+    """
+
+    store_path: Optional[Path]
+    """
+    An optional stable path to the input, as preserved by the `FindInputs` action.
+
+    `store_path` is only present if the `store=/some/dir/` setting is passed in the
+    `FindInputs` configuration **and** the tool actually produces the expected input.
+    """
+
+    content_hash: Optional[str]
+    """
+    A SHA256 hash of the input's content.
+
+    `content_hash` is only present if the `store=/some/dir/` setting is passed in the
+    `FindInputs` configuration **and** the tool actually consumes the expected input.
+    """
+
+
+class InputsRecord(BaseModel):
+    """
+    Represents a single `FindInputs` record. Each record contains a representation
+    of the tool invocation that consumes the inputs, as well as the list of `Input`s
+    associated with the invocation.
+    """
+
+    tool: Tool
+    """
+    The `Tool` invocation.
+    """
+
+    inputs: List[Input]
+    """
+    A list of `Input`s.
+    """
+
+    class Config:
+        arbitrary_types_allowed = True
+        json_encoders = {Tool: lambda t: t.asdict()}
+
+
+class FindInputs(Action):
+    def before_run(self, tool: Tool) -> None:
+        inputs = []
+        for input in tool.inputs:
+            input_path = Path(input)
+            if not input_path.is_absolute():
+                input_path = tool.cwd / input_path
+
+            kind = INPUT_SUFFIX_KIND_MAP.get(input_path.suffix, InputKind.Unknown)
+
+            inputs.append(Input(prenormalized_path=input, kind=kind, path=input_path))
+
+        self._inputs = inputs
+
+    def after_run(self, tool: Tool, *, run_skipped: bool = False) -> None:
+        inputs = InputsRecord(tool=tool, inputs=self._inputs)
+
+        if tool.is_journaling():
+            self._result = inputs.dict()
+        else:
+            output_path = Path(self._config["output"])
+            with flock_append(output_path) as io:
+                print(inputs.json(), file=io)

--- a/src/blight/actions/find_inputs.py
+++ b/src/blight/actions/find_inputs.py
@@ -45,7 +45,7 @@ class Input(BaseModel):
     An optional stable path to the input, as preserved by the `FindInputs` action.
 
     `store_path` is only present if the `store=/some/dir/` setting is passed in the
-    `FindInputs` configuration **and** the tool actually produces the expected input.
+    `FindInputs` configuration **and** the tool actually consumes the expected input.
     """
 
     content_hash: Optional[str]

--- a/src/blight/cli.py
+++ b/src/blight/cli.py
@@ -170,7 +170,7 @@ def exec_(guess_wrapped, swizzle_path, stubs, shims, actions, journal_path, targ
         env["BLIGHT_ACTIONS"] = ":".join(actions)
 
     if journal_path is not None:
-        env["BLIGHT_JOURNAL"] = str(journal_path)
+        env["BLIGHT_JOURNAL_PATH"] = str(journal_path)
 
     env.update({tool.env: tool.blight_tool.value for tool in BuildTool})
 

--- a/src/blight/constants.py
+++ b/src/blight/constants.py
@@ -2,7 +2,7 @@
 Constant tables and maps for various blight APIs and actions.
 """
 
-from blight.enums import OutputKind
+from blight.enums import InputKind, OutputKind
 
 COMPILER_FLAG_INJECTION_VARIABLES = {"CL", "_CL_", "CCC_OVERRIDE_OPTIONS"}
 """
@@ -40,6 +40,24 @@ OUTPUT_SUFFIX_PATTERN_MAP = {
 }
 """
 A mapping of common output suffix patterns to their (expected) file kinds.
+
+This mapping is not exhaustive.
+"""
+
+INPUT_SUFFIX_KIND_MAP = {
+    ".c": InputKind.Source,
+    ".cc": InputKind.Source,
+    ".cpp": InputKind.Source,
+    ".o": InputKind.Object,
+    ".obj": InputKind.Object,
+    ".so": InputKind.SharedLibrary,
+    ".dylib": InputKind.SharedLibrary,
+    ".dll": InputKind.SharedLibrary,
+    ".a": InputKind.StaticLibrary,
+    ".lib": InputKind.StaticLibrary,
+}
+"""
+A mapping of common input suffixes to their (expected) file kinds.
 
 This mapping is not exhaustive.
 """

--- a/src/blight/constants.py
+++ b/src/blight/constants.py
@@ -48,6 +48,7 @@ INPUT_SUFFIX_KIND_MAP = {
     ".c": InputKind.Source,
     ".cc": InputKind.Source,
     ".cpp": InputKind.Source,
+    ".cxx": InputKind.Source,
     ".o": InputKind.Object,
     ".obj": InputKind.Object,
     ".so": InputKind.SharedLibrary,

--- a/src/blight/enums.py
+++ b/src/blight/enums.py
@@ -500,3 +500,19 @@ class OutputKind(str, enum.Enum):
     KernelModule: str = "kernel"
     Directory: str = "directory"
     Unknown: str = "unknown"
+
+
+@enum.unique
+class InputKind(str, enum.Enum):
+    """
+    A collection of common input kinds for build tools.
+
+    This enumeration is not exhaustive.
+    """
+
+    Source: str = "source"
+    Object: str = "object"
+    SharedLibrary: str = "shared"
+    StaticLibrary: str = "static"
+    Directory: str = "directory"
+    Unknown: str = "unknown"

--- a/test/actions/test_find_inputs.py
+++ b/test/actions/test_find_inputs.py
@@ -1,7 +1,5 @@
-import hashlib
 import json
 import os
-
 from pathlib import Path
 
 from blight.actions import FindInputs

--- a/test/actions/test_find_inputs.py
+++ b/test/actions/test_find_inputs.py
@@ -40,12 +40,12 @@ def test_find_outputs_journaling(monkeypatch, tmp_path):
     foo_input = (tmp_path / "foo.c").resolve()
     foo_input.touch()
 
-    find_outputs = FindInputs({})
+    find_inputs = FindInputs({})
     cc = CC(["-c", str(foo_input), "-o", "foo"])
-    find_outputs.before_run(cc)
-    find_outputs.after_run(cc)
+    find_inputs.before_run(cc)
+    find_inputs.after_run(cc)
 
-    inputs = find_outputs._result["inputs"]
+    inputs = find_inputs._result["inputs"]
     assert len(inputs) == 1
     assert inputs[0] == {
         "kind": InputKind.Source.value,

--- a/test/actions/test_find_inputs.py
+++ b/test/actions/test_find_inputs.py
@@ -1,0 +1,58 @@
+import hashlib
+import json
+import os
+
+from pathlib import Path
+
+from blight.actions import FindInputs
+from blight.enums import InputKind
+from blight.tool import CC
+
+
+def test_find_inputs(tmp_path):
+    output = tmp_path / "outputs.jsonl"
+
+    foo_input = (tmp_path / "foo.c").resolve()
+    foo_input.touch()
+
+    find_inputs = FindInputs({"output": output})
+    cwd_path = Path(os.getcwd()).resolve()
+    os.chdir(tmp_path)
+    cc = CC(["-o", "foo", "foo.c"])
+    os.chdir(cwd_path)
+    find_inputs.before_run(cc)
+    find_inputs.after_run(cc)
+
+    inputs = json.loads(output.read_text())["inputs"]
+    assert inputs == [
+        {
+            "kind": InputKind.Source.value,
+            "prenormalized_path": "foo.c",
+            "path": str(foo_input),
+            "store_path": None,
+            "content_hash": None,
+        }
+    ]
+
+
+def test_find_outputs_journaling(monkeypatch, tmp_path):
+    journal_output = tmp_path / "journal.jsonl"
+    monkeypatch.setenv("BLIGHT_JOURNAL_PATH", str(journal_output))
+
+    foo_input = (tmp_path / "foo.c").resolve()
+    foo_input.touch()
+
+    find_outputs = FindInputs({})
+    cc = CC(["-c", str(foo_input), "-o", "foo"])
+    find_outputs.before_run(cc)
+    find_outputs.after_run(cc)
+
+    inputs = find_outputs._result["inputs"]
+    assert len(inputs) == 1
+    assert inputs[0] == {
+        "kind": InputKind.Source.value,
+        "prenormalized_path": str(foo_input),
+        "path": foo_input,
+        "store_path": None,
+        "content_hash": None,
+    }


### PR DESCRIPTION
This action heuristically detects inputs to tools and records them after the tool is run. The tool works much like the existing `FindOutputs` action.