### PR TITLE
Fixes `FindOutput` and `FindInput` actions in journaling mode

### DIFF
--- a/src/blight/actions/find_inputs.py
+++ b/src/blight/actions/find_inputs.py
@@ -32,7 +32,7 @@ class Input(BaseModel):
     `path` for an absolute copy.
     """
 
-    path: str
+    path: Path
     """
     The path to the input, as created by the tool.
 

--- a/src/blight/actions/find_inputs.py
+++ b/src/blight/actions/find_inputs.py
@@ -89,7 +89,7 @@ class FindInputs(Action):
 
             kind = INPUT_SUFFIX_KIND_MAP.get(input_path.suffix, InputKind.Unknown)
 
-            inputs.append(Input(prenormalized_path=input, kind=kind, path=str(input_path)))
+            inputs.append(Input(prenormalized_path=input, kind=kind, path=input_path))
 
         self._inputs = inputs
 

--- a/src/blight/actions/find_inputs.py
+++ b/src/blight/actions/find_inputs.py
@@ -32,7 +32,7 @@ class Input(BaseModel):
     `path` for an absolute copy.
     """
 
-    path: Path
+    path: str
     """
     The path to the input, as created by the tool.
 
@@ -89,7 +89,7 @@ class FindInputs(Action):
 
             kind = INPUT_SUFFIX_KIND_MAP.get(input_path.suffix, InputKind.Unknown)
 
-            inputs.append(Input(prenormalized_path=input, kind=kind, path=input_path))
+            inputs.append(Input(prenormalized_path=input, kind=kind, path=str(input_path)))
 
         self._inputs = inputs
 
@@ -97,7 +97,8 @@ class FindInputs(Action):
         inputs = InputsRecord(tool=tool, inputs=self._inputs)
 
         if tool.is_journaling():
-            self._result = inputs.dict()
+            # NOTE(ms): The `tool` member is excluded to avoid journal bloat.
+            self._result = inputs.dict(exclude={"tool"})
         else:
             output_path = Path(self._config["output"])
             with flock_append(output_path) as io:

--- a/src/blight/actions/find_outputs.py
+++ b/src/blight/actions/find_outputs.py
@@ -38,7 +38,7 @@ class Output(BaseModel):
     `path` for an absolute copy.
     """
 
-    path: str
+    path: Path
     """
     The path to the output, as created by the tool.
 
@@ -114,7 +114,7 @@ class FindOutputs(Action):
                         OutputKind.Unknown,
                     )
 
-            outputs.append(Output(prenormalized_path=output, kind=kind, path=str(output_path)))
+            outputs.append(Output(prenormalized_path=output, kind=kind, path=output_path))
 
         self._outputs = outputs
 
@@ -125,12 +125,11 @@ class FindOutputs(Action):
             store_path.mkdir(parents=True, exist_ok=True)
 
             for output in self._outputs:
-                output_path = Path(output.path)
                 # We don't copy output directories into the store, for now.
-                if output_path.is_dir():
+                if output.path.is_dir():
                     continue
 
-                if not output_path.exists():
+                if not output.path.exists():
                     logger.warning(f"tool={tool}'s output ({output.path}) does not exist")
                     continue
 
@@ -138,10 +137,10 @@ class FindOutputs(Action):
                 # steps in the build system could even modify a particular output
                 # in-place, so we give each output a `store_path` based on a hash
                 # of its content.
-                content_hash = hashlib.sha256(output_path.read_bytes()).hexdigest()
+                content_hash = hashlib.sha256(output.path.read_bytes()).hexdigest()
                 # Append hash to the filename unless `append_hash=false` is specified in the config
                 append_hash = self._config.get("append_hash") != "false"
-                filename = f"{output_path.name}-{content_hash}" if append_hash else output_path.name
+                filename = f"{output.path.name}-{content_hash}" if append_hash else output.path.name
                 output_store_path = store_path / filename
                 if not output_store_path.exists():
                     shutil.copy(output.path, output_store_path)

--- a/src/blight/util.py
+++ b/src/blight/util.py
@@ -291,11 +291,15 @@ def load_actions():
 def json_helper(value: Any):
     """
     A `default` helper for Python's `json`, intended to facilitate
-    serialization of blight classes that use the `asdict` pattern.
+    serialization of blight classes.
     """
 
     if hasattr(value, "asdict"):
         return value.asdict()
+
+    if isinstance(value, Path):
+        return str(value)
+
     raise TypeError
 
 

--- a/test/actions/test_find_inputs.py
+++ b/test/actions/test_find_inputs.py
@@ -5,7 +5,8 @@ from pathlib import Path
 from blight.actions import FindInputs
 from blight.enums import InputKind
 from blight.tool import CC
-
+from blight.actions.find_inputs import Input
+from blight.util import json_helper
 
 def test_find_inputs(tmp_path):
     output = tmp_path / "outputs.jsonl"
@@ -54,3 +55,15 @@ def test_find_inputs_journaling(monkeypatch, tmp_path):
         "store_path": None,
         "content_hash": None,
     }
+
+def test_serialize_input(tmp_path):
+    journal_output = tmp_path / "journal.jsonl"
+    foo_input = (tmp_path / "foo.c").resolve()
+    input = Input(prenormalized_path="foo.c", kind=InputKind.Source, path=foo_input)
+    with open(journal_output, "w") as io:  # type: ignore
+        json.dump(input.dict(), io, default=json_helper)
+        io.write("\n")
+    
+    kwargs = json.loads(journal_output.read_text())
+
+    assert Input(**kwargs).dict() == input.dict()

--- a/test/actions/test_find_inputs.py
+++ b/test/actions/test_find_inputs.py
@@ -33,7 +33,7 @@ def test_find_inputs(tmp_path):
     ]
 
 
-def test_find_outputs_journaling(monkeypatch, tmp_path):
+def test_find_inputs_journaling(monkeypatch, tmp_path):
     journal_output = tmp_path / "journal.jsonl"
     monkeypatch.setenv("BLIGHT_JOURNAL_PATH", str(journal_output))
 

--- a/test/actions/test_find_inputs.py
+++ b/test/actions/test_find_inputs.py
@@ -3,10 +3,11 @@ import os
 from pathlib import Path
 
 from blight.actions import FindInputs
+from blight.actions.find_inputs import Input
 from blight.enums import InputKind
 from blight.tool import CC
-from blight.actions.find_inputs import Input
 from blight.util import json_helper
+
 
 def test_find_inputs(tmp_path):
     output = tmp_path / "outputs.jsonl"
@@ -56,14 +57,10 @@ def test_find_inputs_journaling(monkeypatch, tmp_path):
         "content_hash": None,
     }
 
+
 def test_serialize_input(tmp_path):
-    journal_output = tmp_path / "journal.jsonl"
     foo_input = (tmp_path / "foo.c").resolve()
     input = Input(prenormalized_path="foo.c", kind=InputKind.Source, path=foo_input)
-    with open(journal_output, "w") as io:  # type: ignore
-        json.dump(input.dict(), io, default=json_helper)
-        io.write("\n")
-    
-    kwargs = json.loads(journal_output.read_text())
-
+    input_json = json.dumps(input.dict(), default=json_helper)
+    kwargs = json.loads(input_json)
     assert Input(**kwargs).dict() == input.dict()

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 import pretend
 import pytest
 
@@ -86,6 +89,14 @@ def test_json_helper_asdict():
     has_asdict = pretend.stub(asdict=lambda: {"foo": "bar"})
 
     assert util.json_helper(has_asdict) == {"foo": "bar"}
+
+
+def test_json_helper_path():
+    cwd = os.getcwd()
+    path = cwd / Path("foo")
+    result = util.json_helper(path)
+    assert isinstance(result, str)
+    assert result == f"{cwd}/foo"
 
 
 def test_json_helper_typeerror():


### PR DESCRIPTION
This PR solves an issue where `FindOutput` and `FindInput` would throw a `TypeError` exception when run in journaling mode. The issue was that `Path` members were not easily serializable via `json.dump()`.  I also excluded the `tool` member serialization in journaling mode to not bloat up the journal too much. Previous behavior can be achieved by running `Record` before either of the `Find*` actions.