### PR TITLE
Support for fingerprinting the compiler

### DIFF
--- a/src/blight/enums.py
+++ b/src/blight/enums.py
@@ -119,6 +119,33 @@ class BlightTool(str, enum.Enum):
 
 
 @enum.unique
+class CompilerFamily(enum.Enum):
+    """
+    Models known compiler families (e.g. GCC, Clang, etc.)
+    """
+
+    Gcc = enum.auto()
+    """
+    The GCC family of compilers.
+    """
+
+    MainlineLlvm = enum.auto()
+    """
+    The "mainline" LLVM family, corresponding to upstream releases of LLVM.
+    """
+
+    AppleLlvm = enum.auto()
+    """
+    The "Apple" LLVM family, corresponding to Apple's builds of LLVM.
+    """
+
+    Unknown = enum.auto()
+    """
+    An unknown compiler family.
+    """
+
+
+@enum.unique
 class CompilerStage(enum.Enum):
     """
     Models the known stages that a compiler tool can be in.

--- a/test/test_tool.py
+++ b/test/test_tool.py
@@ -8,7 +8,7 @@ import pretend
 import pytest
 
 from blight import tool, util
-from blight.enums import CodeModel, CompilerStage, Lang, OptLevel, Std
+from blight.enums import CodeModel, CompilerFamily, CompilerStage, Lang, OptLevel, Std
 from blight.exceptions import BlightError, BuildError
 
 
@@ -31,6 +31,50 @@ def test_compilertool_env_warns_on_injection(monkeypatch):
     _ = tool.CC([])
     assert logger.warning.calls == [
         pretend.call("not tracking compiler's own instrumentation: {'_CL_'}")
+    ]
+
+
+@pytest.mark.parametrize(
+    ("stderr", "family"),
+    [
+        (b"Apple clang version 13.1.6 (clang-1316.0.21.2.5)", CompilerFamily.AppleLlvm),
+        (b"clang version 10.0.0-4ubuntu1", CompilerFamily.MainlineLlvm),
+        (b"gcc version 9.4.0 (Ubuntu 9.4.0-1ubuntu1~20.04.1)", CompilerFamily.Gcc),
+        (b"mystery compiler version 1.0.0", CompilerFamily.Unknown),
+        (b"", CompilerFamily.Unknown),
+    ],
+)
+def test_compilertool_family(monkeypatch, stderr, family):
+    logger = pretend.stub(warning=pretend.call_recorder(lambda s: None))
+    monkeypatch.setattr(tool, "logger", logger)
+
+    result = pretend.stub(returncode=0, stderr=stderr)
+    subprocess = pretend.stub(run=pretend.call_recorder(lambda args, **kw: result))
+    monkeypatch.setattr(tool, "subprocess", subprocess)
+
+    cc = tool.CC([])
+    assert cc.family == family
+
+    if stderr == b"":
+        assert logger.warning.calls == [
+            pretend.call("compiler fingerprint failed: frontend didn't produce output for -###?")
+        ]
+    else:
+        assert logger.warning.calls == []
+
+
+def test_compilertool_family_fingerprint_fails(monkeypatch):
+    logger = pretend.stub(warning=pretend.call_recorder(lambda s: None))
+    monkeypatch.setattr(tool, "logger", logger)
+
+    result = pretend.stub(returncode=1)
+    subprocess = pretend.stub(run=pretend.call_recorder(lambda args, **kw: result))
+    monkeypatch.setattr(tool, "subprocess", subprocess)
+
+    cc = tool.CC([])
+    assert cc.family == CompilerFamily.Unknown
+    assert logger.warning.calls == [
+        pretend.call("compiler fingerprint failed: frontend didn't recognize -###?")
     ]
 
 


### PR DESCRIPTION
This isn't included by default in any dictionary representation of the `CompilerTool`, since it involves invoking the wrapped tool (which might have side effects, even though that's extremely unlikely).