### PR TITLE
_cli: `--guess-wrapped` supports env defaults

### DIFF
--- a/src/blight/_cli.py
+++ b/src/blight/_cli.py
@@ -62,9 +62,11 @@ def _export(variable: str, value: str) -> None:
 
 def _guess_wrapped() -> Iterator[Tuple[str, str]]:
     for tool in BuildTool:
-        tool_path = shutil.which(tool.cmd)
+        tool_path = os.getenv(tool.env)
         if tool_path is None:
-            die(f"Couldn't locate {tool} on the $PATH")
+            tool_path = shutil.which(tool.cmd)
+            if tool_path is None:
+                die(f"Couldn't locate {tool} on the $PATH")
 
         yield (tool.blight_tool.env, tool_path)
 

--- a/src/blight/tool.py
+++ b/src/blight/tool.py
@@ -605,13 +605,11 @@ class DefinesMixin:
 
             components = define.split("=", 1)
             name = components[0]
-            if len(components) == 1:
-                # NOTE(ww): 1 is the default macro value.
-                # It's actually an integer at the preprocessor level, but we model everything
-                # as strings here to avoid complicating things.
-                value = "1"
-            else:
-                value = components[1]
+
+            # NOTE(ww): 1 is the default macro value.
+            # It's actually an integer at the preprocessor level, but we model everything
+            # as strings here to avoid complicating things.
+            value = "1" if len(components) == 1 else components[1]
 
             # Is this macro subsequently undefined? If so, don't include it in
             # the defines list.


### PR DESCRIPTION
Closes #43464.

Demo:

```bash
$ blight-env --guess-wrapped
export BLIGHT_WRAPPED_CC=/usr/bin/cc
export BLIGHT_WRAPPED_CXX=/usr/bin/c++
export BLIGHT_WRAPPED_CPP=/usr/bin/cpp
export BLIGHT_WRAPPED_LD=/usr/bin/ld
export BLIGHT_WRAPPED_AS=/usr/bin/as
export BLIGHT_WRAPPED_AR=/usr/bin/ar
export BLIGHT_WRAPPED_STRIP=/usr/bin/strip
export BLIGHT_WRAPPED_INSTALL=/usr/bin/install
export CC=blight-cc
export CXX=blight-c++
export CPP=blight-cpp
export LD=blight-ld
export AS=blight-as
export AR=blight-ar
export STRIP=blight-strip
export INSTALL=blight-install

$ CC=foo blight-env --guess-wrapped
export BLIGHT_WRAPPED_CC=foo
export BLIGHT_WRAPPED_CXX=/usr/bin/c++
export BLIGHT_WRAPPED_CPP=/usr/bin/cpp
export BLIGHT_WRAPPED_LD=/usr/bin/ld
export BLIGHT_WRAPPED_AS=/usr/bin/as
export BLIGHT_WRAPPED_AR=/usr/bin/ar
export BLIGHT_WRAPPED_STRIP=/usr/bin/strip
export BLIGHT_WRAPPED_INSTALL=/usr/bin/install
export CC=blight-cc
export CXX=blight-c++
export CPP=blight-cpp
export LD=blight-ld
export AS=blight-as
export AR=blight-ar
export STRIP=blight-strip
export INSTALL=blight-install
```