### PR TITLE
tool: warn when accessing `Tool.lang`

### DIFF
--- a/src/blight/tool.py
+++ b/src/blight/tool.py
@@ -286,6 +286,10 @@ class LangMixin:
         Returns:
             A `blight.enums.Lang` value representing the tool's language
         """
+        logger.warning(
+            "This API might not do what you expect; see: https://github.com/trailofbits/blight/issues/43493"
+        )
+
         x_lang_map = {"c": Lang.C, "c-header": Lang.C, "c++": Lang.Cxx, "c++-header": Lang.Cxx}
 
         # First, check for `-x lang`. This overrides the language determined by

--- a/src/blight/tool.py
+++ b/src/blight/tool.py
@@ -287,7 +287,7 @@ class LangMixin:
             A `blight.enums.Lang` value representing the tool's language
         """
         logger.warning(
-            "This API might not do what you expect; see: https://github.com/trailofbits/blight/issues/43493"
+            "this API might not do what you expect; see: https://github.com/trailofbits/blight/issues/43493"
         )
 
         x_lang_map = {"c": Lang.C, "c-header": Lang.C, "c++": Lang.Cxx, "c++-header": Lang.Cxx}


### PR DESCRIPTION
This doesn't fix anything, but will hopefully nudge people who are assuming that this API does something smarter than it currently does.