### PR TITLE
Fix dependabot config: weekly schedule, cooldown, grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,21 @@ updates:
   - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: daily
-      time: "10:00"
+      interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Change schedule from daily to weekly for both pip and github-actions ecosystems
- Add `cooldown` with `default-days: 7` to both ecosystems
- Add grouped updates with `patterns: ["*"]` to batch dependency updates

## Test plan
- [ ] Verify Dependabot respects weekly schedule on next run
- [ ] Verify grouped PRs are created instead of individual ones

Generated with [Claude Code](https://claude.com/claude-code)